### PR TITLE
Add light background support to vim-airline theme

### DIFF
--- a/autoload/airline/themes/minimalist.vim
+++ b/autoload/airline/themes/minimalist.vim
@@ -2,66 +2,68 @@
 "
 " Author:       Diki Ananta <diki1aap@gmail.com>
 " Repository:   https://github.com/dikiaap/minimalist
-" Version:      1.5
+" Version:      2.0
 " License:      MIT
 
-" Normal Mode
-let s:N1 = [ '#E4E4E4' , '#3A3A3A' , 254 , 237 ]
-let s:N2 = [ '#E4E4E4' , '#4E4E4E' , 254 , 239 ]
-let s:N3 = [ '#EEEEEE' , '#262626' , 255 , 235 ]
+let s:theme = 'minimalist'
 
-" Insert Mode
-let s:I1 = [ '#E4E4E4' , '#3A3A3A' , 254 , 237 ]
-let s:I2 = [ '#E4E4E4' , '#4E4E4E' , 254 , 239 ]
-let s:I3 = [ '#EEEEEE' , '#262626' , 255 , 235 ]
+function! airline#themes#{s:theme}#refresh()
+    if &background == "dark"
+        " Normal
+        let N1 = [ '#E4E4E4', '#3A3A3A', 254, 237 ]
+        let N2 = [ '#E4E4E4', '#4E4E4E', 254, 239 ]
+        let N3 = [ '#EEEEEE', '#262626', 255, 235 ]
 
-" Visual Mode
-let s:V1 = [ '#E4E4E4' , '#3A3A3A' , 254 , 237 ]
-let s:V2 = [ '#E4E4E4' , '#4E4E4E' , 254 , 239 ]
-let s:V3 = [ '#EEEEEE' , '#262626' , 255 , 235 ]
+        " Inactive
+        let IA = [ '#666666', N3[1], 242, N3[3] ]
 
-" Replace Mode
-let s:R1 = [ '#E4E4E4' , '#3A3A3A' , 254 , 237 ]
-let s:R2 = [ '#E4E4E4' , '#4E4E4E' , 254 , 239 ]
-let s:R3 = [ '#EEEEEE' , '#262626' , 255 , 235 ]
+        " Error
+        let ER = [ '#1C1C1C', '#D75F5F', 234, 167 ]
 
-" Inactive Mode
-let s:IA = [ '#666666' , '#262626' , 242 , 235 , '' ]
+        " Warning
+        let WI = [ ER[0], '#FFAF5F', ER[2], 215 ]
+    else
+        " Normal
+        let N1 = [ 'gray30', 'gray70', 235, 249 ]
+        let N2 = [ 'gray20', 'gray60', 233, 246 ]
+        let N3 = [ 'gray20', 'gray80', 233, 251 ]
 
-let g:airline#themes#minimalist#palette = {}
-let g:airline#themes#minimalist#palette.normal  = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
-let g:airline#themes#minimalist#palette.insert  = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
-let g:airline#themes#minimalist#palette.visual  = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
-let g:airline#themes#minimalist#palette.replace = airline#themes#generate_color_map(s:R1, s:R2, s:R3)
-let g:airline#themes#minimalist#palette.inactive = airline#themes#generate_color_map(s:IA, s:IA, s:IA)
+        " Inactive
+        let IA = [ 'gray15', N3[1], 244, N3[3] ]
 
-" Warning Mode
-let s:WI = [ '#1C1C1C' , '#FFAF5F' , 234 , 215 , '' ]
-let g:airline#themes#minimalist#palette.normal.airline_warning = [
-        \ s:WI[0], s:WI[1], s:WI[2], s:WI[3]
-        \ ]
-let g:airline#themes#minimalist#palette.insert.airline_warning  = g:airline#themes#minimalist#palette.normal.airline_warning
-let g:airline#themes#minimalist#palette.visual.airline_warning  = g:airline#themes#minimalist#palette.normal.airline_warning
-let g:airline#themes#minimalist#palette.replace.airline_warning = g:airline#themes#minimalist#palette.normal.airline_warning
+        " Error
+        let ER = [ '#1C1C1C', '#D75F5F', 234, 167 ]
 
-" Error Mode
-let s:ER = [ '#1C1C1C' , '#D75F5F' , 234 , 167 , '' ]
-let g:airline#themes#minimalist#palette.normal.airline_error = [
-        \ s:ER[0], s:ER[1], s:ER[2], s:ER[3]
-        \ ]
-let g:airline#themes#minimalist#palette.insert.airline_error    = g:airline#themes#minimalist#palette.normal.airline_error
-let g:airline#themes#minimalist#palette.visual.airline_error    = g:airline#themes#minimalist#palette.normal.airline_error
-let g:airline#themes#minimalist#palette.replace.airline_error   = g:airline#themes#minimalist#palette.normal.airline_error
+        " Warning
+        let WI = [ ER[0], '#FFAF5F', ER[2], 215 ]
+    endif
 
-" Accents
-let g:airline#themes#minimalist#palette.accents = {
-        \ 'red': [ '#D75F5F' , '' , 167 , '' ]
-        \ }
+    " Reverse
+    let NR = [ N2[1], N2[0],  N2[3], N2[2], 'bold' ]
 
-" CtrlP
-if get(g:, 'loaded_ctrlp', 0)
-    let g:airline#themes#minimalist#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
-            \ [ '#E4E4E4' , '#262626' , 254 , 235 , ''     ],
-            \ [ '#E4E4E4' , '#4E4E4E' , 254 , 239 , ''     ],
-            \ [ '#585858' , '#E4E4E4' , 240 , 254 , 'bold' ])
-endif
+
+    let palette = {}
+
+    let palette.normal = airline#themes#generate_color_map(N1, N2, N3)
+    let palette.normal.airline_error = ER
+    let palette.normal.airline_warning = WI
+
+    let palette.insert   = palette.normal
+    let palette.replace  = palette.normal
+    let palette.visual   = palette.normal
+    let palette.inactive = airline#themes#generate_color_map(IA, IA, IA)
+
+    " Accents
+    let palette.accents = {
+            \ 'red': [ ER[1], '', ER[3], '' ]
+            \ }
+
+    " CtrlP
+    if get(g:, 'loaded_ctrlp', 0)
+        let palette.ctrlp = airline#extensions#ctrlp#generate_color_map(N3, N2, NR)
+    endif
+
+    let g:airline#themes#{s:theme}#palette = palette
+endfunction
+
+call airline#themes#{s:theme}#refresh()

--- a/autoload/airline/themes/minimalist.vim
+++ b/autoload/airline/themes/minimalist.vim
@@ -1,4 +1,4 @@
-" Minimalist Airline - A Material Color Scheme Darker
+" Minimalist Airline - A Material Color Scheme
 "
 " Author:       Diki Ananta <diki1aap@gmail.com>
 " Repository:   https://github.com/dikiaap/minimalist
@@ -6,6 +6,10 @@
 " License:      MIT
 
 let s:theme = 'minimalist'
+
+" To highlight when the buffer is modified:
+"     let g:airline_minimalist_showmod = 1
+let s:want_showmod = get(g:, 'airline_minimalist_showmod', 0)
 
 function! airline#themes#{s:theme}#refresh()
     if &background == "dark"
@@ -38,25 +42,33 @@ function! airline#themes#{s:theme}#refresh()
         let WI = [ ER[0], '#FFAF5F', ER[2], 215 ]
     endif
 
+    " Terminal
+    let TE = [ ER[0], N1[1], N1[2], N1[3] ]
+
     " Reverse
-    let NR = [ N2[1], N2[0],  N2[3], N2[2], 'bold' ]
+    let NR = [ N2[1], N2[0], N2[3], N2[2], 'bold' ]
 
 
     let palette = {}
 
     let palette.normal = airline#themes#generate_color_map(N1, N2, N3)
-    let palette.normal.airline_error = ER
+    let palette.normal.airline_error   = ER
     let palette.normal.airline_warning = WI
+    let palette.normal.airline_term    = TE
 
     let palette.insert   = palette.normal
     let palette.replace  = palette.normal
     let palette.visual   = palette.normal
     let palette.inactive = airline#themes#generate_color_map(IA, IA, IA)
 
+    if s:want_showmod
+        let palette.normal_modified = { 'airline_a': NR, 'airline_z': NR }
+    endif
+
     " Accents
     let palette.accents = {
-            \ 'red': [ ER[1], '', ER[3], '' ]
-            \ }
+                \ 'red': [ ER[1], '', ER[3], '' ]
+                \ }
 
     " CtrlP
     if get(g:, 'loaded_ctrlp', 0)


### PR DESCRIPTION
This does not change the dark colors. It does remove some extraneous settings which did not have any effect, such as explicitly setting palette.insert / replace / visual (they default to .normal if not set).