### PR TITLE
Make more compatible with indent-blankline.nvim

### DIFF
--- a/colors/minimalist.vim
+++ b/colors/minimalist.vim
@@ -35,7 +35,7 @@ hi IncSearch        ctermfg=234     ctermbg=75      cterm=NONE      guifg=#1C1C1
 hi LineNr           ctermfg=59      ctermbg=234     cterm=NONE      guifg=#5F5F5F       guibg=#1C1C1C   gui=NONE
 hi MatchParen       ctermfg=NONE    ctermbg=NONE    cterm=underline guifg=NONE          guibg=NONE      gui=underline
 hi MoreMsg          ctermfg=150     ctermbg=NONE    cterm=NONE      guifg=#AFD787       guibg=NONE      gui=NONE
-hi NonText          ctermfg=234     ctermbg=234     cterm=NONE      guifg=#1C1C1C       guibg=#1C1C1C   gui=NONE
+hi NonText          ctermfg=234     ctermbg=234     cterm=NONE      guifg=#2A2A2A       guibg=NONE      gui=NONE
 hi Normal           ctermfg=255     ctermbg=234     cterm=NONE      guifg=#EEEEEE       guibg=#1C1C1C   gui=NONE
 hi Pmenu            ctermfg=NONE    ctermbg=NONE    cterm=NONE      guifg=NONE          guibg=NONE      gui=NONE
 hi PmenuSel         ctermfg=NONE    ctermbg=59      cterm=NONE      guifg=NONE          guibg=#5F5F5F   gui=NONE


### PR DESCRIPTION
When using this colorscheme in Neovim with [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) plugin installed, the plugin uses NonText highlight group to highlight the tab lines. This colorscheme uses the same color for foreground and background which makes the cursor invisible when it's under that hl group. This PR makes the background transparent and foreground a little brighter to make the symbols and cursor visible under that hl group (and making the color scheme usable with the plugin).